### PR TITLE
Fix WhatsApp responses with TwiML and enhance logging

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -12,6 +12,8 @@ class RequestLogMiddleware(BaseHTTPMiddleware):
         log.info("start", id=rid, path=request.url.path)
         try:
             resp: Response = await call_next(request)
+            resp_text = getattr(resp, "body", b"")[:200]
+            log.info("response_sample", id=rid, body=resp_text.decode(errors="ignore"))
             log.info("end", id=rid, status=resp.status_code,
                      latency_ms=int((time.time()-start)*1000))
             return resp


### PR DESCRIPTION
## Problem
WhatsApp messages were not appearing despite webhook returning 200 OK status. Responses need to be in TwiML XML format for Twilio/WhatsApp.

## Solution
- TwiML Integration: Added MessagingResponse from Twilio to generate proper XML responses
- Response Format Fix: Replaced all PlainTextResponse with twiml_message function that returns XML
- Enhanced Debugging: Added response body logging to RequestLogMiddleware for better visibility

## Changes
- app/main.py: Added TwiML response function and updated all webhook returns
- app/middleware.py: Added response body logging (first 200 chars) to track what's sent

## Testing
- Server reloads automatically with changes
- Enhanced JSON logging shows request lifecycle
- Response content now visible in logs
- Ready for WhatsApp testing with proper TwiML format

Fixes the core issue where responses weren't appearing in WhatsApp chat.